### PR TITLE
Work pool fix

### DIFF
--- a/batchup/work_pool.py
+++ b/batchup/work_pool.py
@@ -179,7 +179,7 @@ class WorkerPool(object):
 
 
 def _pds_extract_helper(data, batch_indices):  # pragma: no cover
-    return data.samples_by_indices(batch_indices)
+    return data.samples_by_indices_nomapping(batch_indices)
 
 
 class ParallelDataSource(data_source.AbstractDataSource):


### PR DESCRIPTION
`work_pool._pds_extract_helper` invoked `samples_by_indices` method of `RandomAccessDataSource` where it should have invoked `samples_by_indices_nomapping`.