### PR TITLE
Added thread-based implementation to `work_pool`

### DIFF
--- a/batchup/tests/test_work_pool.py
+++ b/batchup/tests/test_work_pool.py
@@ -1,11 +1,13 @@
-import pytest
 import os
+import pytest
+import time
 import numpy as np
+import threading
 
 
 # Define example task function in the root of the module so that pickle can
 # find it
-def _example_task_fn(*args):
+def _example_process_task_fn(*args):
     return sum(args), os.getpid()
 
 
@@ -37,17 +39,47 @@ class _ExampleBatchIteratorError (_AbstractExampleBatchIterator):
 
 
 @pytest.fixture
-def pool():
+def thread_pool():
     from batchup import work_pool
-    return work_pool.WorkerPool(processes=5)
+    return work_pool.WorkerThreadPool(processes=5)
 
 
-def test_work_stream(pool):
+@pytest.fixture
+def process_pool():
+    from batchup import work_pool
+    return work_pool.WorkerProcessPool(processes=5)
+
+
+def test_thread_work_stream(thread_pool):
+    # Example task function
+    def _example_task_fn(*args):
+        time.sleep(0.01)
+        return sum(args), threading.current_thread().ident
+
     def task_generator():
-        for i in range(500):
+        for i in range(50):
             yield _example_task_fn, (i, i, i)
 
-    stream = pool.work_stream(task_generator())
+    stream = thread_pool.work_stream(task_generator())
+
+    thread_ids = set()
+    for i in range(50):
+        v, t_id = stream.retrieve()
+        thread_ids.add(t_id)
+        assert v == i * 3
+
+    assert len(thread_ids) == 5
+
+    # Check that one last call to retrieve returns None
+    assert stream.retrieve() is None
+
+
+def test_process_work_stream(process_pool):
+    def task_generator():
+        for i in range(500):
+            yield _example_process_task_fn, (i, i, i)
+
+    stream = process_pool.work_stream(task_generator())
 
     pids = set()
     for i in range(500):
@@ -61,15 +93,36 @@ def test_work_stream(pool):
     assert stream.retrieve() is None
 
 
-def test_parallel_data_source(pool):
+def test_thread_parallel_data_source(thread_pool):
     from batchup import data_source
+
+    class _AbstractExampleBatchIterator (object):
+        def __init__(self, N):
+            self.N = N
+
+        # Define __len__ here to save us some work in the base classes that we
+        # will actually use
+        def __len__(self):
+            return self.N
+
+    class _ExampleBatchIteratorIdentity (_AbstractExampleBatchIterator):
+        def __getitem__(self, indices):
+            return indices
+
+    class _ExampleBatchIteratorSquare (_AbstractExampleBatchIterator):
+        def __getitem__(self, indices):
+            return indices**2
+
+    class _ExampleBatchIteratorError (_AbstractExampleBatchIterator):
+        def __getitem__(self, indices):
+            raise ValueError
 
     ds = data_source.ArrayDataSource(
         [_ExampleBatchIteratorIdentity(100),
          _ExampleBatchIteratorSquare(100)]
     )
 
-    pds = pool.parallel_data_source(ds)
+    pds = thread_pool.parallel_data_source(ds)
 
     # Check number of samples
     assert ds.num_samples() == 100
@@ -107,7 +160,7 @@ def test_parallel_data_source(pool):
 
     # Check that passing something that isn't a data source fails
     with pytest.raises(TypeError):
-        pool.parallel_data_source(_ExampleBatchIteratorIdentity(100))
+        thread_pool.parallel_data_source(_ExampleBatchIteratorIdentity(100))
 
     # Check that passing a non random access data source fails
     with pytest.raises(TypeError):
@@ -117,18 +170,85 @@ def test_parallel_data_source(pool):
                     yield np.random.normal(size=(batch_size, 2))
         cds = data_source.CallableDataSource(make_batch_iter)
 
-        pool.parallel_data_source(cds)
+        thread_pool.parallel_data_source(cds)
 
     # Check that errors raised by data sources are passed back
     eds = data_source.ArrayDataSource([_ExampleBatchIteratorError(100)])
-    peds = pool.parallel_data_source(eds)
+    peds = thread_pool.parallel_data_source(eds)
     peds_iter = peds.batch_iterator(batch_size=BATCHSIZE,
                                     shuffle=np.random.RandomState(12345))
     with pytest.raises(ValueError):
         next(peds_iter)
 
 
-def test_parallel_data_source_with_index_mapping(pool):
+def test_process_parallel_data_source(process_pool):
+    from batchup import data_source
+
+    ds = data_source.ArrayDataSource(
+        [_ExampleBatchIteratorIdentity(100),
+         _ExampleBatchIteratorSquare(100)]
+    )
+
+    pds = process_pool.parallel_data_source(ds)
+
+    # Check number of samples
+    assert ds.num_samples() == 100
+    assert pds.num_samples() == 100
+
+    # Arrays of flags indicating which numbers we got back
+    n_flags = np.zeros((100,), dtype=bool)
+    n_sqr_flags = np.zeros((10000,), dtype=bool)
+
+    BATCHSIZE = 10
+
+    for batch in pds.batch_iterator(
+            batch_size=BATCHSIZE, shuffle=np.random.RandomState(12345)):
+        # batch should be a list
+        assert isinstance(batch, tuple)
+        # batch should contain two arrays
+        assert len(batch) == 2
+        # each array should be of length BATCHSIZE
+        assert batch[0].shape[0] == BATCHSIZE
+        assert batch[1].shape[0] == BATCHSIZE
+
+        # Check off the numbers we got back
+        n_flags[batch[0]] = True
+        n_sqr_flags[batch[1]] = True
+
+    # Check the flags arrays
+    assert n_flags.sum() == 100
+    assert n_sqr_flags.sum() == 100
+
+    expected_n_flags = np.ones((100,), dtype=bool)
+    expected_n_sqr_flags = np.zeros((10000,), dtype=bool)
+    expected_n_sqr_flags[np.arange(100)**2] = True
+    assert (n_flags == expected_n_flags).all()
+    assert (n_sqr_flags == expected_n_sqr_flags).all()
+
+    # Check that passing something that isn't a data source fails
+    with pytest.raises(TypeError):
+        process_pool.parallel_data_source(_ExampleBatchIteratorIdentity(100))
+
+    # Check that passing a non random access data source fails
+    with pytest.raises(TypeError):
+        def make_batch_iter(**kwargs):
+            def batch_iterator(batch_size):
+                for i in range(0, 100, batch_size):
+                    yield np.random.normal(size=(batch_size, 2))
+        cds = data_source.CallableDataSource(make_batch_iter)
+
+        process_pool.parallel_data_source(cds)
+
+    # Check that errors raised by data sources are passed back
+    eds = data_source.ArrayDataSource([_ExampleBatchIteratorError(100)])
+    peds = process_pool.parallel_data_source(eds)
+    peds_iter = peds.batch_iterator(batch_size=BATCHSIZE,
+                                    shuffle=np.random.RandomState(12345))
+    with pytest.raises(ValueError):
+        next(peds_iter)
+
+
+def test_thread_parallel_data_source_with_index_mapping(thread_pool):
     from batchup import data_source
 
     X = np.zeros((100,), dtype=int)
@@ -139,8 +259,41 @@ def test_parallel_data_source_with_index_mapping(pool):
 
     ds0 = data_source.ArrayDataSource([X], indices=indices0)
     ds1 = data_source.ArrayDataSource([X], indices=indices1)
-    pds0 = pool.parallel_data_source(ds0)
-    pds1 = pool.parallel_data_source(ds1)
+    pds0 = thread_pool.parallel_data_source(ds0)
+    pds1 = thread_pool.parallel_data_source(ds1)
+
+    # Check number of samples
+    assert ds0.num_samples() == 50
+    assert ds1.num_samples() == 50
+    assert pds0.num_samples() == 50
+    assert pds1.num_samples() == 50
+
+    BATCHSIZE = 10
+
+    for batch_X, in pds0.batch_iterator(
+            batch_size=BATCHSIZE, shuffle=np.random.RandomState(12345)):
+        # Ensure that all the return values are 0
+        assert (batch_X == 0).all()
+
+    for batch_X, in pds1.batch_iterator(
+            batch_size=BATCHSIZE, shuffle=np.random.RandomState(12345)):
+        # Ensure that all the return values are 0
+        assert (batch_X == 1).all()
+
+
+def test_process_parallel_data_source_with_index_mapping(process_pool):
+    from batchup import data_source
+
+    X = np.zeros((100,), dtype=int)
+    indices = np.random.RandomState(12345).permutation(100)
+    indices0 = indices[:50]
+    indices1 = indices[50:]
+    X[indices1] = 1
+
+    ds0 = data_source.ArrayDataSource([X], indices=indices0)
+    ds1 = data_source.ArrayDataSource([X], indices=indices1)
+    pds0 = process_pool.parallel_data_source(ds0)
+    pds1 = process_pool.parallel_data_source(ds1)
 
     # Check number of samples
     assert ds0.num_samples() == 50

--- a/batchup/work_pool.py
+++ b/batchup/work_pool.py
@@ -1,6 +1,7 @@
 import sys
 import numpy as np
 import collections
+from multiprocessing.pool import ThreadPool
 import multiprocessing.managers
 from six.moves.cPickle import loads, dumps
 
@@ -8,7 +9,7 @@ import joblib
 
 from . import data_source
 
-SharedConstant = collections.namedtuple('SharedConstant', ['value'])
+_SharedConstant = collections.namedtuple('_SharedConstant', ['value'])
 _SharedRef = collections.namedtuple('_SharedRef', ['key'])
 
 _MAX_PRIMTIVE_ARG_SIZE = 16384
@@ -35,7 +36,7 @@ def _deserialise_args(shared_objects, local_objects,
 def _serialise_args(shared_objects, args):  # pragma: no cover
     serialised_args = []
     for arg in args:
-        if isinstance(arg, SharedConstant):
+        if isinstance(arg, _SharedConstant):
             value = arg.value
             key = id(value)
             if key not in shared_objects:
@@ -48,14 +49,25 @@ def _serialise_args(shared_objects, args):  # pragma: no cover
     return tuple(serialised_args)
 
 
-def _apply_async_helper(shared_objects, fn,
-                        *serialised_args):  # pragma: no cover
+def _apply_async_helper(fn, *args):  # pragma: no cover
+    try:
+        return fn(*args)
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        raise
+
+
+def _apply_async_helper_proc(shared_objects, fn,
+                             *serialised_args):  # pragma: no cover
     try:
         try:
-            local_objects = getattr(_apply_async_helper, '__local_objects')
+            local_objects = getattr(_apply_async_helper_proc,
+                                    '__local_objects')
         except AttributeError:
             local_objects = {}
-            setattr(_apply_async_helper, '__local_objects', local_objects)
+            setattr(_apply_async_helper_proc, '__local_objects',
+                    local_objects)
 
         args = _deserialise_args(shared_objects, local_objects,
                                  serialised_args)
@@ -67,9 +79,9 @@ def _apply_async_helper(shared_objects, fn,
         raise
 
 
-class WorkerPool(object):
+class AbstractWorkerPool (object):
     """
-    Create a pool of worker processes.
+    Abstract pool of workers.
 
     Call the `work_stream` method to create a `WorkStream` instance that can
     be used to perform tasks in a separate process.
@@ -80,23 +92,30 @@ class WorkerPool(object):
     a result will cause the work stream to top up the result buffer as
     necessary.
     """
-
-    def __init__(self, processes=1):
+    def shared_constant(self, x):  # pragma: no cover
         """
-        Constructor
+        Create a shared constant; a constant value or object that is shared
+        between workers. Parameters that are sent to a worker often have to
+        be sent once for each job (e.g. mini-batch). If a large object is
+        sent across processes, the pickling and unpickling can impose an
+        overhead sufficient to eliminate the benefits of parallel processing.
+        Shared constants are sent once and cached by the workers, reducing
+        this overhead. Note this only applies to worker process pools; this
+        method is a no-op in a thread based worker pool.
 
-        :param processes: (default=1) number of processes to start
+        Parameters
+        ----------
+        x
+            The shared constant value
+
+        Returns
+        -------
+        The wrapped shared constant
         """
-        self.__manager = multiprocessing.managers.SyncManager()
-        self.__manager.start()
-        self.__shared_objects = self.__manager.dict({})
-        self.__pool = joblib.pool.MemmapingPool(processes=processes)
+        raise NotImplementedError('Abstract for type {}'.format(type(self)))
 
-    def _apply_async(self, fn, args):
-        serialised_args = _serialise_args(self.__shared_objects, args)
-        return self.__pool.apply_async(
-            _apply_async_helper,
-            (self.__shared_objects, fn) + serialised_args)
+    def _apply_async(self, fn, args):  # pragma: no cover
+        raise NotImplementedError('Abstract for type {}'.format(type(self)))
 
     def work_stream(self, task_generator, task_buffer_size=20):
         """
@@ -113,22 +132,29 @@ class WorkerPool(object):
         ...         #   `np.random.normal(0.0, 1.0, (100, 10))`
         ...         yield np.random.normal, (0.0, 1.0, (100, 10))
         ...
-        >>> pool = WorkerPool()
+        >>> pool = WorkerThreadPool()
         >>> ws = pool.work_stream(task_generator())
         ...
         >>> for x in ws.retrieve_iter():
         ...     # `do_some_work` will be invoked in a separate process
         ...     pass
 
-        :param task_generator: a generator function if the form
-            `task_generator() -> iterator` that yields tasks in the form of
-            tuples that can be passed to `Pool.apply_async` methods; `(fn,)`
-            or `(fn, args)` or `(fn, args, kwargs)` where `fn` is a function
-            that is to be executed in a worker process,
-        :param task_buffer_size: (default=20) the size of the buffer; the
-            work stream will try to ensure that this number of tasks are
-            awaiting completion
-        :return: a `WorkStream` instance
+        Parameters
+        ----------
+        task_generator: generator function
+            A generator function if the form `task_generator() -> iterator`
+            that yields tasks in the form of tuples that can be passed to
+            `Pool.apply_async` methods; `(fn,)` or `(fn, args)` or
+            `(fn, args, kwargs)` where `fn` is a function that is to be
+            executed by a worker.
+
+        task_buffer_size: int (default=20)
+            the size of the buffer; the work stream will try to ensure that
+            this number of tasks are awaiting completion
+
+        Returns
+        -------
+            A `WorkStream` instance
         """
         return WorkStream(self, task_generator,
                           task_buffer_size=task_buffer_size)
@@ -150,7 +176,7 @@ class WorkerPool(object):
         file names or other information that can be used to find locate large
         sources of data.
 
-        >>> pool = WorkerPool()
+        >>> pool = WorkerThreadPool()
         ...
         >>> ds = data_source.ArrayDataSource([
         ...     np.random.normal(size=(100,10)),
@@ -178,12 +204,131 @@ class WorkerPool(object):
         return ParallelDataSource(ds, batch_buffer_size, self)
 
 
+class WorkerThreadPool(AbstractWorkerPool):
+    """
+    A pool of worker threads.
+
+    Call the `work_stream` method to create a `WorkStream` instance that can
+    be used to perform tasks in a separate process.
+
+    The work stream is provided a generator that generates tasks that are to
+    be executed in a pool of threads. The work stream will attempt to
+    ensure that a buffer of results from those tasks is kept full; retrieving
+    a result will cause the work stream to top up the result buffer as
+    necessary.
+    """
+
+    def __init__(self, processes=1):
+        """
+        Constructor
+
+        Parameters
+        ----------
+        processes: int (default=1)
+            Number of threads to start
+        """
+        self.__pool = ThreadPool(processes=processes)
+
+    def shared_constant(self, x):
+        """
+        Shared constants are not needed in thread-based worker pools, so this
+        method returns the value it is passed.
+
+        Parameters
+        ----------
+        x
+            The shared constant value
+
+        Returns
+        -------
+        `x`
+        """
+        return x
+
+    def _apply_async(self, fn, args):
+        return self.__pool.apply_async(_apply_async_helper, (fn,) + args)
+
+
+class WorkerProcessPool(AbstractWorkerPool):
+    """
+    A pool of worker processes.
+
+    Call the `work_stream` method to create a `WorkStream` instance that can
+    be used to perform tasks in a separate process.
+
+    The work stream is provided a generator that generates tasks that are to
+    be executed in a pool of processes. The work stream will attempt to
+    ensure that a buffer of results from those tasks is kept full; retrieving
+    a result will cause the work stream to top up the result buffer as
+    necessary.
+    """
+
+    def __init__(self, processes=1):
+        """
+        Constructor
+
+        Parameters
+        ----------
+        processes: int (default=1)
+            Number of processes to start
+        """
+        self.__manager = multiprocessing.managers.SyncManager()
+        self.__manager.start()
+        self.__shared_objects = self.__manager.dict({})
+        self.__pool = joblib.pool.MemmapingPool(processes=processes)
+
+    def shared_constant(self, x):
+        """
+        Create a shared constant; a constant value or object that is shared
+        between workers. Parameters that are sent to a worker often have to
+        be sent once for each job (e.g. mini-batch). If a large object is
+        sent across processes, the pickling and unpickling can impose an
+        overhead sufficient to eliminate the benefits of parallel processing.
+        Shared constants are sent once and cached by the workers, reducing
+        this overhead.
+
+        Parameters
+        ----------
+        x
+            The shared constant value
+
+        Returns
+        -------
+        The wrapped shared constant
+        """
+        return _SharedConstant(x)
+
+    def _apply_async(self, fn, args):
+        serialised_args = _serialise_args(self.__shared_objects, args)
+        return self.__pool.apply_async(
+            _apply_async_helper_proc,
+            (self.__shared_objects, fn) + serialised_args)
+
+
 def _pds_extract_helper(data, batch_indices):  # pragma: no cover
     return data.samples_by_indices_nomapping(batch_indices)
 
 
 class ParallelDataSource(data_source.AbstractDataSource):
+    """
+    A data source that wraps an underlying data source that will generate
+    mini-batches in parallel, using a worker pool
+    """
     def __init__(self, ds, batch_buffer_size, pool):
+        """
+        Constructor
+
+        Parameters
+        ----------
+        ds: AbstractDataSource
+            The data source to wrap
+
+        batch_buffer_size: int
+            How many mini-batches to buffer up
+
+        pool: AbstractWorkerPool
+            The pool to process mini-batches in parallel
+        """
         if not isinstance(ds, data_source.AbstractDataSource):
             raise TypeError(
                 'ds must implement `data_source.AbstractDataSource`')
@@ -191,6 +336,7 @@ class ParallelDataSource(data_source.AbstractDataSource):
             raise TypeError('ds must be random access; it is of type '
                             '{}'.format(type(ds)))
         self.__ds = ds
+        self.__shared_ds = pool.shared_constant(ds)
         self.__batch_buffer_size = batch_buffer_size
         self.__pool = pool
 
@@ -201,8 +347,7 @@ class ParallelDataSource(data_source.AbstractDataSource):
         def task_generator():
             for ndx_batch in self.__ds.batch_indices_iterator(
                     batch_size, **kwargs):
-                yield _pds_extract_helper, (SharedConstant(self.__ds),
-                                            ndx_batch)
+                yield _pds_extract_helper, (self.__shared_ds, ndx_batch)
 
         ws = self.__pool.work_stream(
             task_generator(), task_buffer_size=self.__batch_buffer_size)
@@ -216,7 +361,23 @@ class WorkStream(object):
     """
 
     def __init__(self, worker_pool, task_generator, task_buffer_size=20):
-        assert isinstance(worker_pool, WorkerPool)
+        """
+        Constructor
+
+        Parameters
+        ----------
+        worker_pool: AbstractWorkerPool
+            The worker pool which is used to execute tasks
+
+        task_generator: iterator
+            An iterator that generates tasks of the form
+            `(fn, args_as_tuple)`
+
+        task_buffer_size: int (default=20)
+            A hint telling the stream how many tasks - complete or
+            incomplete - should be kept in the buffer
+        """
+        assert isinstance(worker_pool, AbstractWorkerPool)
         self.__task_gen = task_generator
         self.__buffer_size = task_buffer_size
         self.__result_buffer = collections.deque()
@@ -243,7 +404,10 @@ class WorkStream(object):
         Retrieve a result from executing a task. Note that tasks are executed
         in order and that if the next task has not yet completed, this call
         will block until the result is available.
-        :return: the result returned by the task function.
+
+        Returns
+        -------
+        A result from the result buffer.
         """
         if len(self.__result_buffer) > 0:
             res = self.__result_buffer.popleft()
@@ -257,10 +421,12 @@ class WorkStream(object):
 
     def retrieve_iter(self):
         """
-        Retrieve a result from executing a task. Note that tasks are executed
-        in order and that if the next task has not yet completed, this call
-        will block until the result is available.
-        :return: the result returned by the task function.
+        Create an iterator that will retrieve tasks from the buffer until
+        all tasks have been executed.
+
+        Returns
+        -------
+        An iterator that yields values that result from completing tasks.
         """
         while len(self.__result_buffer) > 0:
             res = self.__result_buffer.popleft()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [aliases]
 dev = develop easy_install batchup[testing]
 
-[pytest]
+[tool:pytest]
 addopts =
     -v --doctest-modules
     --cov=batchup --cov-report=term-missing


### PR DESCRIPTION
Can now use either process-based or thread-based worker pools to parallelise mini-batch generation.